### PR TITLE
Add rules to plaintext CID

### DIFF
--- a/draft-duke-quic-load-balancers.md
+++ b/draft-duke-quic-load-balancers.md
@@ -219,13 +219,15 @@ normative:
    The first two bits of an SCID MUST NOT be routing bits; these are
    reserved for config rotation.
 
-    The load balancer selects a divisor that MUST be larger than the
+   The load balancer selects a divisor that MUST be larger than the
    number of servers. It SHOULD be large enough to accommodate reasonable
-   increases in the number of servers.
+   increases in the number of servers. The divisor MUST be an odd integer
+   so certain addition operations do not always produce an even number.
  
    The load balancer also assigns each server a "modulus", an integer
    between 0 and the divisor minus 1. These MUST be unique for each
-   server.
+   server, and SHOULD be distributed across the entire number space
+   between zero and the divisor.
 
    The load balancer shares these three values with servers, as explained
    in {{protocol-description}}.


### PR DESCRIPTION
A few additional rules should make this even more robust to analysis.

The odd number foils this attack: I connect to a server and conduct a bunch of migrations to get lots of new connection IDs. If the divisor is an even number, the last bit of the routing mask will *always* be the same. This dramatically reduces the number of combinations I need to consider when deciphering the routing mask, and right away divides the server pool into two detectable halves.