### PR TITLE
Make config rotation part of the config

### DIFF
--- a/draft-duke-quic-load-balancers.md
+++ b/draft-duke-quic-load-balancers.md
@@ -366,6 +366,9 @@ For Block Cipher CID Routing, this consists of the Server ID, Server ID Length,
 Key, and Zero-Padding Length. The Server ID is unique to each server, but the
 others MUST be global.
 
+Each routing configuration also requires a unique two-bit config rotation
+codepoint (see {{config-rotation}}) to identify it.
+
 ## Out of band sharing
 
 When there are concerns about the integrity of the path between load balancer


### PR DESCRIPTION
Even if all out-of-band, you can't build the CID without them. Fixes #25