### PR TITLE
removed protocol

### DIFF
--- a/draft-duke-quic-load-balancers.md
+++ b/draft-duke-quic-load-balancers.md
@@ -50,10 +50,10 @@ QUIC connection IDs allow continuation of connections across address/port
 load balancers.  They also can prevent linkability of connections across
 deliberate address migration through the use of protected communications between
 client and server.  This creates issues for load-balancing intermediaries.  This
-specification standardizes methods for encoding routing information and proposes
-an optional protocol called QUIC-LB to exchange the parameters of that encoding.
-This framework also enables offload of other QUIC functions to trusted
-intermediaries, given the explicit cooperation of the QUIC server.
+specification standardizes methods for encoding routing information given a
+small set of configuration parameters. This framework also enables offload of
+other QUIC functions to trusted intermediaries, given the explicit cooperation
+of the QUIC server.
 
 --- middle
 
@@ -84,12 +84,10 @@ server-generated connection IDs, and will not route packets correctly if they
 use a connection ID that was originally communicated in a protected
 NEW_CONNECTION_ID frame.
 
-This specification provides a method of coordination between QUIC servers and
-low-state load balancers to support connection IDs that encode routing
-information.  It describes desirable properties of a solution, and then
-specifies a protocol that provides those properties. This protocol supports
-multiple encoding schemes that increase in complexity as they address paths
-between load balancer and server with weaker trust dynamics.
+This specification provides common algorithms for encoding the server mapping in
+a connection ID given some shared parameters. The mapping is generally only
+discoverable by observers that have the parameters, preserving unlinkability as
+much as possible.
 
 Aside from load balancing, a QUIC server may also desire to offload other
 protocol functions to trusted intermediaries. These intermediaries might
@@ -98,6 +96,12 @@ decrypted QUIC packets. For example, this document specifies a means of
 offloading stateless retry to counter Denial of Service attacks. It also
 proposes a system for self-encoding connection ID length in all packets, so that
 crypto offload can consistently look up key information.
+
+While this document describes a small set of configuration parameters to make
+the server mapping intelligible, the means of distributing these parameters
+between load balancers, servers, and other trusted intermediaries is out of its
+scope. There are numerous well-known infrastructures for distribution of
+configuration.
 
 ## Terminology
 
@@ -117,15 +121,6 @@ IP addresses or conduct other IP or UDP processing.
 Note that stateful load balancers that act as proxies, by terminating a QUIC
 connection with the client and then retrieving data from the server using QUIC
 or another protocol, are treated as a server with respect to this specification.
-
-When discussing security threats to QUIC-LB, we distinguish between
-"inside observers" and "outside observers." The former lie on the path between
-the load balancer and server, which often but not always lies inside the
-server's data center or cloud deployment. Outside observers are on the path
-between the load balancer and client. "Off-path" attackers, though not on any
-data path, may also be "inside" or "outside" depending on whether not they have
-network access to the server without intermediation by the load balancer and/or
-other security devices.
 
 # Protocol Objectives
 
@@ -155,27 +150,8 @@ that two connection IDs map to the same server is helpful to linking two
 connection IDs. Obviously, any scheme that transparently communicates this
 mapping to outside observers compromises QUIC's defenses against linkability.
 
-However, concealing this mapping from inside observers is beyond the scope of
-QUIC-LB.  By simply observing Link-Layer and/or Network-Layer addresses of
-packets containing distinct connection IDs, it is trivial to determine that they
-map to the same server, even if connection IDs are entirely random and do not
-encode routing information.  Schemes that conceal these addresses (e.g., IPsec)
-can also conceal QUIC-LB messages.
-
-Inside observers are generally able to mount Denial of Service (DoS) attacks on
-QUIC connections regardless of Connection ID schemes.  However, QUIC-LB should
-protect against Denial of Service due to inside off-path attackers in cases
-where such attackers are possible.
-
 Though not an explicit goal of the QUIC-LB design, concealing the server mapping
 also complicates attempts to focus attacks on a specific server in the pool.
-
-## Robustness to Middleboxes
-
-The path between load balancer and server may pass through middleboxes that
-could drop the coordination messages in this protocol.  It is therefore
-advantageous to make messages resemble QUIC traffic as much as possible, as any
-viable path must obviously admit QUIC traffic.
 
 ## Load Balancer Chains
 
@@ -223,10 +199,11 @@ accelerate this process.
 
 ## Configuration Failover
 
-If a server is configured to expect QUIC-LB messages, and it has not received
-these, it MUST generate connection IDs with the config rotation bits set to
-'11' and MUST use the "disable_migration" transport parameter in all new QUIC
-connections. It MUST NOT send NEW_CONNECTION_ID frames with new values.
+If a server has not received a valid QUIC-LB configuration, and believes that
+low-state, Connection-ID aware load balancers are in the path, it SHOULD
+generate connection IDs with the config rotation bits set to '11' and SHOULD use
+the "disable_migration" transport parameter in all new QUIC connections. It
+SHOULD NOT send NEW_CONNECTION_ID frames with new values.
 
 A load balancer that sees a connection ID with config rotation bits set to
 '11' MUST revert to 5-tuple routing.
@@ -240,10 +217,10 @@ to efficiently lookup these keys if the connection ID does not self-encode its
 own length.
 
 Note that this is a function of particular server devices and is irrelevant to
-load balancers. As such, it is not negotiated between servers and load
-balancers. However, the remaining 6 bits in the first octet of the Connection ID
-are reserved to express the length of the following connection ID, not
-including the first octet.
+load balancers. As such, load balancers MAY omit this from their configuration.
+However, the remaining 6 bits in the first octet of the Connection ID are
+reserved to express the length of the following connection ID, not including
+the first octet.
 
 A server not using this functionality SHOULD make the six bits appear to be
 random.
@@ -282,16 +259,14 @@ accordance with the chosen routing algorithm.
 The load balancer MUST NOT make the routing behavior dependent on any bits in
 the first octet of the QUIC packet header, except the first bit, which indicates
 a long header. All other bits are QUIC version-dependent and intermediaries
-should not build their design on version-specific templates.
+would cannot build their design on version-specific templates.
 
 There are situations where a server pool might be operating two or more routing
 algorithms or parameter sets simultaneously.  The load balancer uses the first
 two bits of the connection ID to multiplex incoming DCIDs over these schemes.
 
-This section describes two participants: the load balancer and the server. The
-load balancer, in this description, generates configuration parameters. Note
-that in practice a third party configuration agent MAY assume this
-responsibility.
+This section describes three participants: the configuration agent, the load
+balancer, and the server.
 
 ## Plaintext CID Algorithm {#plaintext-cid-algorithm}
 
@@ -310,18 +285,19 @@ depicted in the figure below.
 ~~~~~
 {: #plaintext-cid-format title="Plaintext CID Format"}
 
+### Configuration Agent Actions
+
+The configuration agent selects a number of bytes of the server connection ID
+(SCID) to encode individual server IDs, called the "routing bytes". The number
+of bytes MUST have enough entropy to have a different code point for each
+server.
+
+It also assigns a server ID to each server.
+
 ### Load Balancer Actions
 
-The load balancer selects a number of bytes of the server connection ID
-(SCID) that it will use to route to a given server, called the "routing bytes".
-The number of bytes MUST have enough entropy to have a different code point for
-each server.
-
-The load balancer shares this value with servers, as explained in
-{{protocol-description}}, along with the value that represents that server.
-
 On each incoming packet, the load balancer extracts consecutive octets,
-beginning with the second byte. These bytes represent the server ID.
+beginning with the second. These bytes represent the server ID.
 
 ### Server Actions
 
@@ -348,29 +324,28 @@ encryption and decryption. The format is depicted in the figure below.
 ~~~~~
 {: #obfuscated-cid-format title="Obfuscated CID Format"}
 
-### Load Balancer Actions
+### Configuration Agent Actions
 
-The load balancer selects an arbitrary set of bits of the server connection ID
-(SCID) that it will use to route to a given server, called the "routing bits".
-The number of bits MUST have enough entropy to have a different code point for
-each server, and SHOULD have enough entropy so that there are many codepoints
-for each server.
+The configuration agent selects an arbitrary set of bits of the server
+connection ID (SCID) that it will use to route to a given server, called the
+"routing bits". The number of bits MUST have enough entropy to have a different
+code point for each server, and SHOULD have enough entropy so that there are
+many codepoints for each server.
 
-The load balancer MUST NOT select a routing mask with more than 136 routing
-bits set to 1, which allows for the first octet and up to 2 octets for server
-purposes in a maximum-length connection ID.
+The configuration agent MUST NOT select a routing mask with more than 136
+routing bits set to 1, which allows for the first octet and up to 2 octets for
+server purposes in a maximum-length connection ID.
 
-The load balancer selects a divisor that MUST be larger than the number of
+The configuration agent selects a divisor that MUST be larger than the number of
 servers.  It SHOULD be large enough to accommodate reasonable increases in the
 number of servers. The divisor MUST be an odd integer so certain addition
 operations do not always produce an even number.
 
-The load balancer also assigns each server a "modulus", an integer between 0 and
-the divisor minus 1. These MUST be unique for each server, and SHOULD be
+The configuration agent also assigns each server a "modulus", an integer between
+0 and the divisor minus 1. These MUST be unique for each server, and SHOULD be
 distributed across the entire number space between zero and the divisor.
 
-The load balancer shares these three values with servers, as explained in
-{{protocol-description}}.
+### Load Balancer Actions
 
 Upon receipt of a QUIC packet, the load balancer extracts the selected bits of
 the SCID and expresses them as an unsigned integer of that length.  The load
@@ -421,19 +396,18 @@ depicted below.
 ~~~~~
 {: #stream-cipher-cid-format title="Stream Cipher CID Format"}
 
-### Load Balancer Actions
+### Configuration Agent Actions
 
-The load balancer assigns a server ID to every server in its pool, and
+The configuration agent assigns a server ID to every server in its pool, and
 determines a server ID length (in octets) sufficiently large to encode all
 server IDs, including potential future servers.
 
-The load balancer also selects a nonce length and an 16-octet AES-ECB key to use
-for connection ID decryption.  The nonce length MUST be at least 8 octets and no
-more than 16 octets. The nonce length and server ID length MUST sum to 19 or
-fewer octets.
+The configuration agent also selects a nonce length and an 16-octet AES-ECB key
+to use for connection ID decryption.  The nonce length MUST be at least 8 octets
+and no more than 16 octets. The nonce length and server ID length MUST sum to 19
+or fewer octets.
 
-The load balancer shares these three values with servers, as explained in
-{{protocol-description}}.
+### Load Balancer Actions
 
 Upon receipt of a QUIC packet that is not of type Initial or 0-RTT, the load
 balancer extracts as many of the earliest octets from the destination connection
@@ -493,29 +467,28 @@ least 17 octets, increasing overhead of client-to-server packets.
 ~~~~~
 {: #block-cipher-cid-format title="Block Cipher CID Format"}
 
-### Load Balancer Actions
+### Configuration Agent Actions
 
-The load balancer assigns a server ID to every server in its pool, and
+The configuration agent assigns a server ID to every server in its pool, and
 determines a server ID length (in octets) sufficiently large to encode all
 server IDs, including potential future servers.  The server ID will start in the
 second octet of the decrypted connection ID and occupy continuous octets beyond
 that.
 
-The load balancer selects a zero-padding length. This SHOULD be at least four
-octets to allow detection of non-compliant DCIDs. The server ID and zero-
+The configuration agent selects a zero-padding length. This SHOULD be at least
+four octets to allow detection of non-compliant DCIDs. The server ID and zero-
 padding length MUST sum to no more than 16 octets. They SHOULD sum to no more
 than 12 octets, to provide servers adequate space to encode their own opaque
 data.
 
-The load balancer also selects an 16-octet AES-ECB key to use for connection ID
-decryption.
+The configuration agent also selects an 16-octet AES-ECB key to use for
+connection ID decryption.
 
-The load balancer shares these four values with servers, as explained in
-{{protocol-description}}.
+### Load Balancer Actions
 
-Upon receipt of a QUIC packet that is not of type Initial or 0-RTT, the load
-balancer reads the first octet to obtain the config rotation bits. It then
-decrypts the subsequent 16 octets using AES-ECB decryption and the chosen key.
+Upon receipt of a QUIC packet, the load balancer reads the first octet to
+obtain the config rotation bits. It then decrypts the subsequent 16 octets using
+AES-ECB decryption and the chosen key.
 
 The decrypted plaintext contains the server id, zero padding, and opaque server
 data in that order. The load balancer uses the server ID octets for routing.
@@ -586,8 +559,8 @@ service fail for any reason. That is, if the service is not operational, the
 server MUST NOT be exposed to client traffic. Otherwise, servers that have
 already disabled their Retry capability would be vulnerable to attack.
 
-The path between service and server MUST be free of any potential attackers. Note
-that this and other requirements above severely restrict the operational
+The path between service and server MUST be free of any potential attackers.
+Note that this and other requirements above severely restrict the operational
 conditions in which a no-shared-state retry service can safely operate.
 
 Retry tokens generated by the service MUST have the format below.
@@ -728,9 +701,11 @@ such as congestion window, RTT, or MTU. Opaque data SHOULD also allow servers
 to distinguish between retry tokens (which trigger use of the
 original_connection_id transport parameter) and NEW_TOKEN frame tokens.
 
-### Service Requirements
+### Configuration Agent Actions
 
-The service MUST share a "token key" with all supported servers.
+The configuration agent generates and distributes a "token key."
+
+### Service Requirements
 
 When in active mode, the service MUST generate Retry tokens with the format
 described above when it receives a client Initial packet with no token.
@@ -755,12 +730,8 @@ contains a retry token.
 
 # Configuration Requirements
 
-QUIC-LB strives to minimize the configuration load to enable, as much as
-possible, a "plug-and-play" model. However, there are some configuration
-requirements based on algorithm and protocol choices above.
-
-If there is any in-band communication, servers MUST be explicitly configured
-with the token of the load balancer they expect to interface with.
+QUIC-LB requires common configuration to synchronize understanding of encodings
+and guarantee explicit consent of the server.
 
 The load balancer and server MUST agree on a routing algorithm and the relevant
 parameters for that algorithm.
@@ -830,328 +801,10 @@ packet. The comments signify the range of acceptable values where applicable.
 } routing_algorithm_config;
 ~~~
 
-This specification allows for out-of-band dissemination of this configuration
-items, but also provides an in-band method for deployment models that need it.
-
-# Protocol Description {#protocol-description}
-
-There are multiple means of configuration that correspond to differing
-deployment models and increasing levels of concern about the security of the
-load balancer-server path.
-
-## Out of band sharing
-
-When there are concerns about the integrity of the path between load balancer
-and server, operators MAY share routing information using an out-of-band
-technique, which is out of the scope of this specification.
-
-To simplify configuration, the global parameters can be shared out-of-band,
-while the load balancer sends the unique server IDs via the truncated message
-formats presented below.
-
-## QUIC-LB Message Exchange
-
-QUIC-LB load balancers and servers exchange messages via the QUIC-LBv1 protocol,
-which uses the QUIC invariants with version number 0xF1000000. The QUIC-LB
-load balancers send the encoding parameters to servers and periodically
-retransmit until that server responds with an acknowledgement. Specifics of this
-retransmission are implementation-dependent.
-
-## QUIC-LB Packet {#quic-lb-packet}
-
-A QUIC-LB packet uses a long header.  It carries configuration information from
-the load balancer and acknowledgements from the servers.  They are sent when a
-load balancer boots up, detects a new server in the pool or needs to update the
-server configuration.
-
-~~~~~
-0                   1                   2                   3
-0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+
-|1|C R| Reserved|
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                        Version (32)                           |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|  0x00 | 0x00  |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                                                               |
-+                  Authentication Token (64)                    +
-|                                                               |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-| Message Type  |
-+-+-+-+-+-+-+-+-+
-~~~~~
-{: #quic-lb-packet-format title="QUIC-LB Packet Format"}
-
-The Version field allows QUIC-LB to use the Version Negotiation mechanism.  All
-messages in this specification are specific to QUIC-LBv1.  It should be set to
-0xF1000000.
-
-Load balancers MUST cease sending QUIC-LB packets of this version to a server
-when that server sends a Version Negotiation packet that does not advertise the
-version.
-
-The length of the DCIL and SCIL fields are 0x00.
-
-CR
-
-: The 2-bit CR field indicates the Config Rotation described in
-  {{config-rotation}}.
-
-Authentication Token
-
-: The Authentication Token is an 8-byte field that both entities obtain at
-  configuration time. It is used to verify that the sender is not an inside
-  off-path attacker. Servers and load balancers SHOULD silently discard QUIC-LB
-  packets with an incorrect token.
-
-Message Type
-
-: The Message Type indicates the type of message payload that follows the
-  QUIC-LB header.
-
-## Message Types and Formats
-
-As described in {{quic-lb-packet}}, QUIC-LB packets contain a single message.
-This section describes the format and semantics of the QUIC-LB message types.
-
-### ACK_LB Message {#message-ack-lb}
-
-A server uses the ACK_LB message (type=0x00) to acknowledge a QUIC-LB packet
-received from the load balancer.  The ACK-LB message has no additional payload
-beyond the QUIC-LB packet header.
-
-Load balancers SHOULD continue to retransmit a QUIC-LB packet until a valid
-ACK_LB message, FAIL message or Version Negotiation Packet is received from the
-server.
-
-### FAIL Message {#message-fail}
-
-A server uses the FAIL message (type=0x01) to indicate the configuration
-received from the load balancer is unsupported.
-
-~~~~~
-0                   1                   2                   3
-0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|   Supp. Type  |  Supp. Type   |  ...
-+-+-+-+-+-+-+-+-++-+-+-+-+-+-+-+-++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~~~~~
-
-Servers MUST send a FAIL message upon receipt of a message type which they do
-not support, or if they do not possess all of the implied out-of-band
-configuration to support a particular message type.
-
-The payload of the FAIL message consists of a list of all the message types
-supported by the server.
-
-Upon receipt of a FAIL message, Load Balancers MUST either send a QUIC-LB
-message the server supports or remove the server from the server pool.
-
-### ROUTING_INFO Message {#message-routing-info}
-
-A load balancer uses the ROUTING_INFO message (type=0x02) to exchange all the
-parameters for the Obfuscated CID algorithm.
-
-~~~~~
-0                   1                   2                   3
-0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                                                               |
-+                                                               +
-|                                                               |
-+                       Routing Bit Mask (152)                  +
-|                                                               |
-+                                                               +
-|                                                               |
-+                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                               |         Modulus (16)          |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|         Divisor (16)          |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~~~~~
-
-Routing Bit Mask
-
-: The Routing Bit Mask encodes a '1' at every bit position in the server
- connection ID that will encode routing information.
-
-These bits, along with the Modulus and Divisor,  are chosen by the load balancer
-as described in {{obfuscated-cid-algorithm}}.
-
-### STREAM_CID Message {#message-stream-cid}
-
-A load balancer uses the STREAM_CID message (type=0x03) to exchange all the
-parameters for using Stream Cipher CIDs.
-
-~~~~~
-0                   1                   2                   3
-0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-| Nonce Len (8) |    SIDL (8)   |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                       Server ID (variable)                    |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                                                               |
-+                             Key (128)                         +
-|                                                               |
-+                                                               +
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~~~~~
-{: #Stream-cid-format title="Stream CID Payload"}
-
-Nonce Len
-
-: The Nonce Len field is a one-octet unsigned integer that describes the
-  nonce length necessary to use this routing algorithm, in octets.
-
-SIDL
-
-: The SIDL field is a one-octet unsigned integer that describes the server ID
-  length necessary to use this routing algorithm, in octets.
-
-Server ID
-
-: The Server ID is the unique value assigned to the receiving server. Its
-  length is determined by the SIDL field.
-
-Key
-
-: The Key is an 16-octet field that contains the key that the load balancer
-  will use to decrypt server IDs on QUIC packets.  See
-  {{security-considerations}} to understand why sending keys in plaintext may
-  be a safe strategy.
-
-### BLOCK_CID Message {#message-block-cid}
-
-A load balancer uses the BLOCK_CID message (type=0x04) to exchange all the
-parameters for using Stream Cipher CIDs.
-
-~~~~~
-0                   1                   2                   3
-0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|   ZP Len (8)  |    SIDL (8)   |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                       Server ID (variable)                    |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                                                               |
-+                             Key (128)                         +
-|                                                               |
-+                                                               +
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~~~~~
-{: #block-cid-format title="Block CID Payload"}
-
-ZP Len
-
-: The ZP Len field is a one-octet unsigned integer that describes the
-  zero-padding length necessary to use this routing algorithm, in octets.
-
-SIDL
-
-: The SIDL field is a one-octet unsigned integer that describes the server ID
-  length necessary to use this routing algorithm, in octets.
-
-Server ID
-
-: The Server ID is the unique value assigned to the receiving server. Its
-  length is determined by the SIDL field.
-
-Key
-
-: The Key is an 16-octet field that contains the key that the load balancer
-  will use to decrypt server IDs on QUIC packets.  See
-  {{security-considerations}} to understand why sending keys in plaintext may
-  be a safe strategy.
-
-### SERVER_ID Message {#message-server-id}
-
-A load balancer uses the SERVER_ID message (type=0x05) to exchange
-explicit server IDs.
-
-~~~~~
-0                   1                   2                   3
-0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|    SIDL (8)   |       Server ID (variable)    |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~~~~~
-
-Load balancers send the SERVER_ID message when all global values for Stream or
-Block CIDs are sent out-of-band, so that only the server-unique values must be
-sent in-band. It also provides all necessary paramters for Plaintext CIDs. The
-fields are identical to their counterparts in the {{message-stream-cid}}
-payload.
-
-### MODULUS Message {#message-modulus}
-
-A load balancer uses the MODULUS message (type=0x06) to exchange just the
-modulus used in the Obfuscated CID algorithm.
-
-~~~~~
-0                   1                   2                   3
-0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|           Modulus (16)        |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~~~~~
-
-Load balancers send the MODULUS when all global values for Obfuscated CIDs
-are sent out-of-band, so that only the server-unique values must be sent
-in-band. The Modulus field is identical to its counterpart in the
-ROUTING_INFO message.
-
-### PLAINTEXT Message {#message-plaintext}
-
-A load balancer uses the PLAINTEXT message (type=0x07) to exchange all
-parameters needed for the Plaintext CID algorithm.
-
-~~~~~
-0                   1                   2                   3
-0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|   SIDL (8)  |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                                                               |
-+                      Server ID (variable)                     +
-|                                                               |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~~~~~
-
-The SIDL field indicates the length of the server ID field. The
-Server ID field indicates the encoding that represents the
-destination server.
-
-### RETRY_SERVICE_STATELESS message
-
-A no-shared-state retry service uses this message (type=0x08) to notify the
-server of the existence of this service. This message has no fields.
-
-### RETRY_SERVICE_STATEFUL message
-
-A shared-state retry service uses this message (type=0x09) to tell the server
-about its existence, and share the key needed to decrypt server-generated retry
-tokens.
-
-~~~~~
-0                   1                   2                   3
-0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                                                               |
-+                                                               +
-|                                                               |
-+                           Key (128)                           +
-|                                                               |
-+                                                               +
-|                                                               |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~~~~~
-
 # Security Considerations {#security-considerations}
 
-QUIC-LB is intended to preserve routability and prevent linkability.  Attacks on
-the protocol would compromise at least one of these objectives.
+QUIC-LB is intended to prevent linkability.  Attacks would therefore attempt to
+subvert this purpose.
 
 Note that the Plaintext CID algorithm makes no attempt to obscure the server
 mapping, and therefore does not address these concerns. It exists to allow
@@ -1161,44 +814,32 @@ generate new CIDs for the Server Initial Packet and SHOULD NOT send CIDs
 in QUIC NEW_CONNECTION_ID frames. Doing so might falsely suggest to the client
 that said CIDs were generated in a secure fashion.
 
-A routability attack would inject QUIC-LB messages so that load balancers
-incorrectly route QUIC connections.
-
 A linkability attack would find some means of determining that two connection
 IDs route to the same server. As described above, there is no scheme that
 strictly prevents linkability for all traffic patterns, and therefore efforts to
 frustrate any analysis of server ID encoding have diminishing returns.
 
-## Outside attackers
+## Attackers not between the load balancer and server
 
-For an outside attacker to break routability, it must inject packets that
-correctly guess the 64-bit token, and servers must be reachable from these
-outside hosts. Load balancers SHOULD drop QUIC-LB packets that arrive on its
-external interface.
+Any attacker might open a connection to the server infrastructure and
+aggressively retire connection IDs to obtain a large sample of IDs that map to
+the same server. It could then apply analytical techniques to try to obtain the
+server encoding.
 
-Off-path outside attackers cannot observe connection IDs, and will therefore
-struggle to link them.
-
-On-path outside attackers might try to link connection IDs to the same QUIC
-connection.  The Encrypted CID algorithm provides robust entropy to making any
-sort of linkage.  The Obfuscated CID obscures the mapping and prevents trivial
+The Encrypted CID algorithm provides robust entropy to making any sort of
+linkage.  The Obfuscated CID obscures the mapping and prevents trivial
 brute-force attacks to determine the routing parameters, but does not provide
 robust protection against sophisticated attacks.
 
-## Inside Attackers
+Were this analysis to obtain the server encoding, then on-path observers might
+apply this analysis to correlating different client IP addresses.
 
-As described above, on-path inside attackers are intrinsically able to map two
+## Attackers between the load balancer and server
+
+Attackers in this privileged position are intrinsically able to map two
 connection IDs to the same server.  The QUIC-LB algorithms do prevent the
 linkage of two connection IDs to the same individual connection if servers make
 reasonable selections when generating new IDs for that connection.
-
-On-path inside attackers can break routability for new and migrating connections
-by copying the token from QUIC-LB messages.  From this privileged position,
-however, there are many other attacks that can break QUIC connections to the
-server during the handshake.
-
-Off-path inside attackers cannot observe connection IDs to link them.  To
-successfully break routability, they must correctly guess the token.
 
 # IANA Considerations
 
@@ -1212,6 +853,9 @@ There are no IANA requirements.
 
 > **RFC Editor's Note:**  Please remove this section prior to
 > publication of a final version of this document.
+
+## since-draft-duke-quic-load-balancers-06
+- Removed in-band protocol from the document
 
 ## Since draft-duke-quic-load-balancers-05
 - Editorial changes

--- a/draft-duke-quic-load-balancers.md
+++ b/draft-duke-quic-load-balancers.md
@@ -297,7 +297,7 @@ It also assigns a server ID to each server.
 ### Load Balancer Actions
 
 On each incoming packet, the load balancer extracts consecutive octets,
-beginning with the second. These bytes represent the server ID.
+beginning with the second octet. These bytes represent the server ID.
 
 ### Server Actions
 


### PR DESCRIPTION
In response to feedback from the room in Singapore, I stripped the message protocol out of the document.  This may rise again in another document if there is sufficient demand. (I am going to try to convene a summit of cloud load balancer types between now and Zurich.)

This deletes text about the protocol, and greatly simplifies the security considerations.

Please try to get comments in this week. I plan to commit on Monday and publish draft-07 shortly thereafter.